### PR TITLE
feat: 탭 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.2",
         "tailwind-merge": "^2.5.5",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8",
         "zustand": "^5.0.1"
@@ -12567,6 +12568,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.15",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",
     "tailwind-merge": "^2.5.5",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8",
     "zustand": "^5.0.1"

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import sectionSlider from "@/lib/sectionSlider";
 import { usePathname, useRouter } from "next/navigation";
+import { useRef } from "react";
 
 interface Props {
   tabs: Tab[];
@@ -13,11 +15,21 @@ interface Tab {
 }
 
 export default function Tabs({ tabs }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const path = usePathname();
   const currentId = path.split("/").pop()?.split("?")[0] ?? "";
+
   return (
-    <div className="flex gap-4 px-6">
+    <div
+      role="button"
+      tabIndex={0}
+      onMouseDown={(e) => {
+        sectionSlider(e, containerRef);
+      }}
+      ref={containerRef}
+      className="flex w-full gap-4 overflow-auto px-6 scrollbar-hide"
+    >
       {tabs.map((tab) => {
         const isSelected = tab.value === currentId;
         return (
@@ -27,7 +39,7 @@ export default function Tabs({ tabs }: Props) {
               onClick={() => {
                 router.push(tab.path);
               }}
-              className={`p-3 text-sm sm:text-base ${isSelected && "font-bold"}`}
+              className={`whitespace-nowrap p-4 text-sm sm:text-base ${isSelected && "font-bold"} w-auto`}
             >
               {tab.name}
             </button>

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+interface Props {
+  tabs: Tab[];
+}
+
+interface Tab {
+  name: string;
+  value: string;
+  path: string;
+}
+
+export default function Tabs({ tabs }: Props) {
+  const router = useRouter();
+  const path = usePathname();
+  const slash = path.split("/");
+  const id = slash[slash.length - 1].split("?")[0];
+  return (
+    <div className="flex gap-[16px] px-[24px]">
+      {tabs.map((tab) => {
+        return (
+          <div key={tab.value} className="flex flex-col items-center">
+            <button
+              type="button"
+              onClick={() => {
+                router.push(tab.path);
+              }}
+              className={`p-[16px] text-sm sm:text-base ${tab.value === id && "font-bold"}`}
+            >
+              {tab.name}
+            </button>
+            {tab.value === id && <div className="h-[2px] w-full bg-black" />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -15,11 +15,11 @@ interface Tab {
 export default function Tabs({ tabs }: Props) {
   const router = useRouter();
   const path = usePathname();
-  const slash = path.split("/");
-  const id = slash[slash.length - 1].split("?")[0];
+  const currentId = path.split("/").pop()?.split("?")[0] ?? "";
   return (
-    <div className="flex gap-[16px] px-[24px]">
+    <div className="flex gap-4 px-6">
       {tabs.map((tab) => {
+        const isSelected = tab.value === currentId;
         return (
           <div key={tab.value} className="flex flex-col items-center">
             <button
@@ -27,11 +27,11 @@ export default function Tabs({ tabs }: Props) {
               onClick={() => {
                 router.push(tab.path);
               }}
-              className={`p-[16px] text-sm sm:text-base ${tab.value === id && "font-bold"}`}
+              className={`p-3 text-sm sm:text-base ${isSelected && "font-bold"}`}
             >
               {tab.name}
             </button>
-            {tab.value === id && <div className="h-[2px] w-full bg-black" />}
+            {isSelected && <div className="h-0.5 w-full bg-black" />}
           </div>
         );
       })}

--- a/src/lib/sectionSlider.ts
+++ b/src/lib/sectionSlider.ts
@@ -1,0 +1,23 @@
+const sectionSlider = (e: React.MouseEvent<HTMLDivElement>, containerRef: React.RefObject<HTMLDivElement>) => {
+  const container = containerRef.current;
+  if (!container) return;
+
+  const startX = e.pageX - container.offsetLeft;
+  const { scrollLeft } = container;
+
+  const onMouseMove = (moveEvent: MouseEvent) => {
+    const x = moveEvent.pageX - container.offsetLeft;
+    const walk = (x - startX) * 1.5;
+    container.scrollLeft = scrollLeft - walk;
+  };
+
+  const onMouseUp = () => {
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
+  };
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+};
+
+export default sectionSlider;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -76,5 +76,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("tailwind-scrollbar-hide")],
 } satisfies Config;


### PR DESCRIPTION
## 🔢 관련 이슈

- close #15 

## 📌 작업 개요

공통 탭 컴포넌트 구현

## 📝 작업 상세

- 클릭시 해당 url로 이동하며 해당 탭의 스타일이 바뀌고 다른 탭의 스타일이 디폴트로 돌아가게 구현
- 요소가 많아져 화면에서 벗어날 시 슬라이드로 확인 가능

## 🎸 기타 참고 사항

사용하실 때 props로 배열 넣어주시면 됩니다

`
[
 {
    name: "탭에 표시할 이름(string)",
    value: "고유값(string)",
    path: "url에 들어갈 경로(string)",
 },
 {
    name: "탭에 표시할 이름(string)",
    value: "고유값(string)",
    path: "url에 들어갈 경로(string)",
 }
...
]
`