### PR TITLE
feat: 태그 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.2",
         "tailwind-merge": "^2.5.5",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8",
         "zustand": "^5.0.1"
@@ -12567,6 +12568,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.15",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",
     "tailwind-merge": "^2.5.5",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8",
     "zustand": "^5.0.1"

--- a/src/components/common/Tags.tsx
+++ b/src/components/common/Tags.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  tags: Tag[];
+}
+
+interface Tag {
+  name: string;
+  value: string;
+}
+
+export default function Tags({ tags }: Props) {
+  const router = useRouter();
+  const path = usePathname();
+  const searchParams = useSearchParams();
+  const query = searchParams.get("sub");
+  return (
+    <div className="my-[16px] flex gap-2">
+      {tags?.map((tag) => {
+        return (
+          <Button
+            key={tag.value}
+            variant="secondary"
+            type="button"
+            onClick={() => {
+              router.push(`${path}?sub=${tag.value}`);
+            }}
+            className={`text-xs sm:text-base ${tag.value.includes(query as string) ? "bg-[#E1E2E8] font-bold text-[#5A25E9]" : "bg-[#F8F8FA]"} rounded-[12px] px-[16px] py-[12px] text-sm sm:text-base`}
+          >
+            {tag.name}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/common/Tags.tsx
+++ b/src/components/common/Tags.tsx
@@ -2,6 +2,8 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { useRef } from "react";
+import sectionSlider from "@/lib/sectionSlider";
 
 interface Props {
   tags: Tag[];
@@ -13,12 +15,22 @@ interface Tag {
 }
 
 export default function Tags({ tags }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const path = usePathname();
   const searchParams = useSearchParams();
   const query = searchParams.get("sub");
+
   return (
-    <div className="my-[16px] flex gap-2">
+    <div
+      role="button"
+      tabIndex={0}
+      ref={containerRef}
+      onMouseDown={(e) => {
+        sectionSlider(e, containerRef);
+      }}
+      className="my-4 flex w-full cursor-grab gap-2 overflow-x-auto overflow-y-hidden whitespace-nowrap scrollbar-hide"
+    >
       {tags?.map((tag) => {
         return (
           <Button
@@ -28,7 +40,7 @@ export default function Tags({ tags }: Props) {
             onClick={() => {
               router.push(`${path}?sub=${tag.value}`);
             }}
-            className={`text-xs sm:text-base ${tag.value.includes(query as string) ? "bg-[#E1E2E8] font-bold text-[#5A25E9]" : "bg-[#F8F8FA]"} rounded-[12px] px-[16px] py-[12px] text-sm sm:text-base`}
+            className={`${tag.value.includes(query as string) ? "bg-gray-300 font-bold text-main" : "bg-gray-100"} rounded-xl px-4 py-3 text-sm sm:text-base`}
           >
             {tag.name}
           </Button>

--- a/src/lib/sectionSlider.ts
+++ b/src/lib/sectionSlider.ts
@@ -1,0 +1,23 @@
+const sectionSlider = (e: React.MouseEvent<HTMLDivElement>, containerRef: React.RefObject<HTMLDivElement>) => {
+  const container = containerRef.current;
+  if (!container) return;
+
+  const startX = e.pageX - container.offsetLeft;
+  const { scrollLeft } = container;
+
+  const onMouseMove = (moveEvent: MouseEvent) => {
+    const x = moveEvent.pageX - container.offsetLeft;
+    const walk = (x - startX) * 1.5;
+    container.scrollLeft = scrollLeft - walk;
+  };
+
+  const onMouseUp = () => {
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
+  };
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+};
+
+export default sectionSlider;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -76,5 +76,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("tailwind-scrollbar-hide")],
 } satisfies Config;


### PR DESCRIPTION
## 🔢 관련 이슈

- close #16  

## 📌 작업 개요
공통 태그 컴포넌트 구현

## 📝 작업 상세

- 클릭시 해당 태그의 쿼리가 속한 url로 이동하며 해당 태그의 스타일이 바뀌고 다른 태그의 스타일이 디폴트로 돌아가게 구현
- 요소가 많아져 화면에서 벗어날 시 슬라이드로 확인 가능

## 🎸 기타 참고 사항

사용하실 때 props로 배열 넣어주시면 됩니다

`[ { name: "태그에 표시할 이름(string)", value: "쿼리값(string)",  }, { name: "태그에 표시할 이름(string)", value: "쿼리값(string)", } ... ]`