### PR TITLE
test: 회원가입 테스트 코드 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",
@@ -4455,6 +4456,19 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",

--- a/src/app/(auth)/signup/_component/SelectButton.test.tsx
+++ b/src/app/(auth)/signup/_component/SelectButton.test.tsx
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SelectButton } from "./SelectButton";
+
+describe("SelectButton 컴포넌트", () => {
+  it("버튼이 렌더링된다", () => {
+    render(<SelectButton>셀렉트 버튼 테스트</SelectButton>);
+    expect(screen.getByText("셀렉트 버튼 테스트")).toBeInTheDocument();
+  });
+
+  it("selected 상태에 따라 스타일이 변경된다", () => {
+    const { rerender } = render(<SelectButton>테스트</SelectButton>);
+    expect(screen.getByRole("button")).toHaveClass("bg-gray-100", "text-gray-900");
+
+    rerender(<SelectButton selected>테스트</SelectButton>);
+    expect(screen.getByRole("button")).toHaveClass("bg-gray-250", "text-main");
+  });
+
+  it("클릭 시 onClick 핸들러가 호출된다", () => {
+    const handleClick = jest.fn();
+    render(<SelectButton onClick={handleClick}>테스트</SelectButton>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(auth)/signup/_component/StepIndicator.test.tsx
+++ b/src/app/(auth)/signup/_component/StepIndicator.test.tsx
@@ -1,0 +1,20 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { StepIndicator } from "./StepIndicator";
+
+describe("StepIndicator 컴포넌트", () => {
+  it("전달받은 steps 수 만큼 indicator가 렌더링된다", () => {
+    const { container } = render(<StepIndicator steps={3} currentStep={1} />);
+    const indicators = container.querySelectorAll(".rounded-full");
+    expect(indicators).toHaveLength(3);
+  });
+
+  it("현재 단계에 해당하는 인디케이터에 활성화 클래스가 적용된다", () => {
+    const { container } = render(<StepIndicator steps={3} currentStep={2} />);
+    const indicators = container.querySelectorAll(".rounded-full");
+
+    expect(indicators[1]).toHaveClass("bg-main");
+    expect(indicators[0]).toHaveClass("bg-gray-300");
+    expect(indicators[2]).toHaveClass("bg-gray-300");
+  });
+});

--- a/src/app/(auth)/signup/_component/StepOne.test.tsx
+++ b/src/app/(auth)/signup/_component/StepOne.test.tsx
@@ -1,0 +1,160 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { SignUpFormData } from "@/types/auth";
+import { DEFAULT_SIGNUP_VALUES, signUpSchema } from "@/schemas/auth";
+import { Form } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { FORM_LABELS } from "@/constants/formLabels";
+import { VALIDATION_ERRORS } from "@/constants/messages";
+import { StepOne } from "./StepOne";
+
+function StepOneWrapper() {
+  const form = useForm<SignUpFormData>({
+    defaultValues: DEFAULT_SIGNUP_VALUES,
+    resolver: zodResolver(signUpSchema),
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <StepOne form={form} />
+        <Button type="submit">다음으로</Button>
+      </form>
+    </Form>
+  );
+}
+
+beforeEach(() => {
+  render(<StepOneWrapper />);
+});
+
+describe("StepOne 컴포넌트", () => {
+  describe("UI 렌더링", () => {
+    it("닉네임, 이메일, 비밀번호 입력 필드가 화면에 나타난다", () => {
+      const fields = [
+        { label: FORM_LABELS.name.label, placeholder: FORM_LABELS.name.placeholder },
+        { label: FORM_LABELS.email.label, placeholder: FORM_LABELS.email.placeholder },
+        { label: FORM_LABELS.password.label, placeholder: FORM_LABELS.password.placeholder },
+        { label: FORM_LABELS.passwordConfirm.label, placeholder: FORM_LABELS.passwordConfirm.placeholder },
+      ];
+
+      fields.forEach(({ label, placeholder }) => {
+        expect(screen.getByText(label)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
+      });
+    });
+
+    it("로그인 링크가 존재하고 올바른 href를 가진다", () => {
+      const loginLink = screen.getByRole("link", { name: "로그인" });
+      expect(loginLink).toHaveAttribute("href", "/login");
+    });
+  });
+
+  describe("비밀번호 토글 기능", () => {
+    const passwordFields = [
+      {
+        toggleName: "비밀번호 보기/숨기기 토글",
+        placeholder: FORM_LABELS.password.placeholder,
+      },
+      {
+        toggleName: "비밀번호 확인 보기/숨기기 토글",
+        placeholder: FORM_LABELS.passwordConfirm.placeholder,
+      },
+    ];
+
+    passwordFields.forEach(({ toggleName, placeholder }) => {
+      it(`${toggleName} 버튼이 정상적으로 작동한다`, async () => {
+        const input = screen.getByPlaceholderText(placeholder) as HTMLInputElement;
+        const toggleButton = screen.getByRole("button", {
+          name: toggleName,
+        });
+
+        expect(input.type).toBe("password");
+        expect(toggleButton).toBeInTheDocument();
+
+        await userEvent.click(toggleButton);
+        expect(input.type).toBe("text");
+
+        await userEvent.click(toggleButton);
+        expect(input.type).toBe("password");
+      });
+    });
+  });
+
+  describe("유효성 검사", () => {
+    const errorTestCases = [
+      {
+        description: "닉네임이 2자 미만이면 에러 메시지가 표시된다",
+        placeholder: FORM_LABELS.name.placeholder,
+        errorMessage: VALIDATION_ERRORS.name.min,
+        invalidValue: "김",
+      },
+      {
+        description: "닉네임이 10자 초과이면 에러 메시지가 표시된다",
+        placeholder: FORM_LABELS.name.placeholder,
+        errorMessage: VALIDATION_ERRORS.name.max,
+        invalidValue: "매우긴닉네임테스트중입니다",
+      },
+      {
+        description: "이메일 형식이 올바르지 않으면 에러 메시지가 표시된다",
+        placeholder: FORM_LABELS.email.placeholder,
+        errorMessage: VALIDATION_ERRORS.email.invalid,
+        invalidValue: "invalid-email",
+      },
+      {
+        description: "비밀번호 형식이 올바르지 않으면 에러 메시지가 표시된다",
+        placeholder: FORM_LABELS.password.placeholder,
+        errorMessage: VALIDATION_ERRORS.password.requirements,
+        invalidValue: "error!",
+      },
+    ];
+
+    errorTestCases.forEach(({ description, placeholder, invalidValue, errorMessage }) => {
+      it(description, async () => {
+        const input = screen.getByPlaceholderText(placeholder);
+        const submitButton = screen.getByRole("button", { name: "다음으로" });
+
+        await userEvent.type(input, invalidValue);
+        await userEvent.click(submitButton);
+
+        expect(await screen.findByText(errorMessage)).toBeInTheDocument();
+      });
+    });
+
+    it("비밀번호가 일치하지 않으면 에러 메시지가 표시된다", async () => {
+      const passwordInput = screen.getByPlaceholderText(FORM_LABELS.password.placeholder);
+      const confirmInput = screen.getByPlaceholderText(FORM_LABELS.passwordConfirm.placeholder);
+      const submitButton = screen.getByRole("button", { name: "다음으로" });
+
+      await userEvent.type(passwordInput, "Valid123!");
+      await userEvent.type(confirmInput, "Wrong123!");
+      await userEvent.click(submitButton);
+
+      expect(await screen.findByText(VALIDATION_ERRORS.password.notMatch)).toBeInTheDocument();
+    });
+
+    it("올바른 값을 입력하면 에러 메시지가 표시되지 않는다", async () => {
+      await userEvent.type(screen.getByPlaceholderText(FORM_LABELS.name.placeholder), "테스트");
+      await userEvent.type(screen.getByPlaceholderText(FORM_LABELS.email.placeholder), "test@example.com");
+      await userEvent.type(screen.getByPlaceholderText(FORM_LABELS.password.placeholder), "Valid123!");
+      await userEvent.type(screen.getByPlaceholderText(FORM_LABELS.passwordConfirm.placeholder), "Valid123!");
+
+      await userEvent.click(screen.getByRole("button", { name: "다음으로" }));
+
+      const errorMessages = [
+        VALIDATION_ERRORS.name.min,
+        VALIDATION_ERRORS.name.max,
+        VALIDATION_ERRORS.email.invalid,
+        VALIDATION_ERRORS.password.notMatch,
+        VALIDATION_ERRORS.password.requirements,
+      ];
+
+      errorMessages.forEach((message) => {
+        expect(screen.queryByText(message)).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/app/(auth)/signup/_component/StepOne.tsx
+++ b/src/app/(auth)/signup/_component/StepOne.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { SignUpFormData } from "@/types/auth";
 import Link from "next/link";
 import { FormFieldWrapper } from "@/components/common/FormFieldWrapper";
+import { FORM_LABELS } from "@/constants/formLabels";
 
 interface StepOneProps {
   form: UseFormReturn<SignUpFormData>;
@@ -19,19 +20,34 @@ export function StepOne({ form }: StepOneProps) {
   return (
     <>
       <h1 className="mb-8 text-center text-2xl font-bold">회원가입</h1>
-      <FormFieldWrapper control={form.control} name="name" label="닉네임" placeholder="사용할 닉네임을 입력해 주세요" />
-      <FormFieldWrapper control={form.control} name="email" label="아이디" placeholder="이메일을 입력해 주세요" />
+      <FormFieldWrapper
+        control={form.control}
+        name="name"
+        label={FORM_LABELS.name.label}
+        placeholder={FORM_LABELS.name.placeholder}
+      />
+      <FormFieldWrapper
+        control={form.control}
+        name="email"
+        label={FORM_LABELS.email.label}
+        placeholder={FORM_LABELS.email.placeholder}
+      />
       <FormFieldWrapper
         control={form.control}
         name="password"
-        label="비밀번호"
+        label={FORM_LABELS.password.label}
         renderContent={(field) => (
           <div className="relative">
-            <Input type={showPassword ? "text" : "password"} placeholder="비밀번호를 입력해주세요" {...field} />
+            <Input
+              type={showPassword ? "text" : "password"}
+              placeholder={FORM_LABELS.password.placeholder}
+              {...field}
+            />
             <button
               type="button"
               onClick={() => setShowPassword(!showPassword)}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
+              aria-label="비밀번호 보기/숨기기 토글"
             >
               {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
             </button>
@@ -41,18 +57,19 @@ export function StepOne({ form }: StepOneProps) {
       <FormFieldWrapper
         control={form.control}
         name="passwordConfirm"
-        label="비밀번호 확인"
+        label={FORM_LABELS.passwordConfirm.label}
         renderContent={(field) => (
           <div className="relative">
             <Input
               type={showPasswordConfirm ? "text" : "password"}
-              placeholder="비밀번호를 다시 한 번 입력해주세요"
+              placeholder={FORM_LABELS.passwordConfirm.placeholder}
               {...field}
             />
             <button
               type="button"
               onClick={() => setShowPasswordConfirm(!showPasswordConfirm)}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
+              aria-label="비밀번호 확인 보기/숨기기 토글"
             >
               {showPasswordConfirm ? <Eye size={20} /> : <EyeOff size={20} />}
             </button>

--- a/src/app/(auth)/signup/_component/StepTwo.test.tsx
+++ b/src/app/(auth)/signup/_component/StepTwo.test.tsx
@@ -1,0 +1,96 @@
+import "@testing-library/jest-dom";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { SignUpFormData } from "@/types/auth";
+import { Form } from "@/components/ui/form";
+import { REGIONS, CATEGORIES } from "@/constants/options";
+import { StepTwo } from "./StepTwo";
+
+function StepTwoWrapper() {
+  const form = useForm<SignUpFormData>({
+    defaultValues: {
+      name: "테스트",
+      email: "",
+      password: "",
+      passwordConfirm: "",
+      regions: ["ALL"],
+      interestCategories: ["ALL"],
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <StepTwo form={form} />
+    </Form>
+  );
+}
+
+beforeEach(() => {
+  render(<StepTwoWrapper />);
+});
+
+describe("StepTwo 컴포넌트", () => {
+  describe("UI 렌더링", () => {
+    it("사용자 이름이 표시된다", () => {
+      expect(screen.getByText("테스트 님의 관심 카테고리")).toBeInTheDocument();
+    });
+
+    it("활동할 지역과 카테고리 필드가 표시된다", () => {
+      expect(screen.getByText("활동할 지역")).toBeInTheDocument();
+      expect(screen.getByText("관심 카테고리")).toBeInTheDocument();
+
+      const regionSection = screen.getByTestId("regions-section");
+      REGIONS.forEach(({ label }) => {
+        const button = within(regionSection).getByRole("button", { name: label });
+        expect(button).toBeInTheDocument();
+      });
+
+      const interestCategoriesSection = screen.getByTestId("interestCategories-section");
+      CATEGORIES.forEach(({ label }) => {
+        const button = within(interestCategoriesSection).getByRole("button", { name: label });
+        expect(button).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("버튼 선택 동작", () => {
+    describe("지역 선택", () => {
+      it("특정 지역 선택 시 '전체' 선택이 해제된다", async () => {
+        const regionSection = screen.getByTestId("regions-section");
+        const seoulButton = within(regionSection).getByRole("button", { name: "서울" });
+        await userEvent.click(seoulButton);
+
+        const allButton = within(regionSection).getByRole("button", { name: "전체" });
+        expect(allButton).not.toHaveClass("bg-gray-250");
+        expect(seoulButton).toHaveClass("bg-gray-250");
+      });
+
+      it("'전체' 선택 시 다른 모든 지역 선택이 해제된다", async () => {
+        const regionSection = screen.getByTestId("regions-section");
+        const seoulButton = within(regionSection).getByRole("button", { name: "서울" });
+        const busanButton = within(regionSection).getByRole("button", { name: "부산" });
+
+        await userEvent.click(seoulButton);
+        await userEvent.click(busanButton);
+
+        const allButton = within(regionSection).getByRole("button", { name: "전체" });
+        await userEvent.click(allButton);
+
+        expect(allButton).toHaveClass("bg-gray-250");
+        expect(seoulButton).not.toHaveClass("bg-gray-250");
+        expect(busanButton).not.toHaveClass("bg-gray-250");
+      });
+
+      it("선택된 지역을 모두 해제하면 자동으로 '전체'가 선택된다", async () => {
+        const regionSection = screen.getByTestId("regions-section");
+        const seoulButton = within(regionSection).getByRole("button", { name: "서울" });
+        await userEvent.click(seoulButton);
+        await userEvent.click(seoulButton);
+
+        const allButton = within(regionSection).getByRole("button", { name: "전체" });
+        expect(allButton).toHaveClass("bg-gray-250");
+      });
+    });
+  });
+});

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -52,7 +52,7 @@ export default function SignUp() {
           {step === 1 ? <StepOne form={form} /> : <StepTwo form={form} />}
           <StepIndicator steps={2} currentStep={step} />
           <div className="space-y-4">
-            <Button type="submit" className="h-12 w-full bg-black hover:bg-black/90">
+            <Button type="submit" className="h-12 w-full">
               {step === 1 ? "다음으로" : "확인"}
             </Button>
             {step === 2 && (

--- a/src/components/common/FormFieldWrapper.tsx
+++ b/src/components/common/FormFieldWrapper.tsx
@@ -23,7 +23,7 @@ export function FormFieldWrapper({
       control={control}
       name={name}
       render={({ field }) => (
-        <FormItem>
+        <FormItem data-testid={`${name}-section`}>
           <FormLabel className="text-base">{label}</FormLabel>
           <FormControl>
             {renderContent ? renderContent(field) : <Input placeholder={placeholder} type={type} {...field} />}

--- a/src/constants/formLabels.ts
+++ b/src/constants/formLabels.ts
@@ -1,0 +1,18 @@
+export const FORM_LABELS = {
+  name: {
+    label: "닉네임",
+    placeholder: "사용할 닉네임을 입력해 주세요",
+  },
+  email: {
+    label: "이메일",
+    placeholder: "이메일을 입력해 주세요",
+  },
+  password: {
+    label: "비밀번호",
+    placeholder: "비밀번호를 입력해 주세요",
+  },
+  passwordConfirm: {
+    label: "비밀번호 확인",
+    placeholder: "비밀번호를 다시 한번 입력해 주세요",
+  },
+};

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,19 @@
+export const VALIDATION_ERRORS = {
+  name: {
+    min: "닉네임은 2자 이상이어야 합니다",
+    max: "닉네임은 10자 이하여야 합니다",
+  },
+  email: {
+    required: "이메일을 입력해 주세요",
+    invalid: "올바른 이메일 형식이 아닙니다",
+  },
+  password: {
+    requirements: "8글자 이상, 영문, 숫자, 특수문자를 모두 포함해야 합니다.",
+    confirmRequired: "비밀번호를 다시 한번 입력해 주세요.",
+    notMatch: "비밀번호가 일치하지 않습니다",
+  },
+  stepTwo: {
+    regionRequired: "활동 지역을 선택해 주세요",
+    categoryRequired: "관심 카테고리를 선택해 주세요",
+  },
+} as const;

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -9,7 +9,12 @@ export const signUpSchema = z
   .object({
     name: z.string().min(2, "닉네임은 2자 이상이어야 합니다").max(10, "닉네임은 10자 이하여야 합니다"),
     email: z.string().min(1, "이메일을 입력해주세요").email("올바른 이메일 형식이 아닙니다"),
-    password: z.string(),
+    password: z
+      .string()
+      .regex(
+        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
+        "8글자 이상, 영문, 숫자, 특수문자를 모두 포함해야 합니다.",
+      ),
     passwordConfirm: z.string().min(1, "비밀번호를 다시 한 번 입력해주세요"),
     regions: z.array(z.enum(REGION_VALUES)).min(1, "활동 지역을 선택해주세요"),
     interestCategories: z.array(z.enum(CATEGORY_VALUES)).min(1, "관심 카테고리를 선택해주세요"),

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,3 +1,4 @@
+import { VALIDATION_ERRORS } from "@/constants/messages";
 import { CATEGORIES, REGIONS } from "@/constants/options";
 import { SignUpFormData } from "@/types/auth";
 import * as z from "zod";
@@ -7,20 +8,17 @@ export const CATEGORY_VALUES = CATEGORIES.map((c) => c.value) as [string, ...str
 
 export const signUpSchema = z
   .object({
-    name: z.string().min(2, "닉네임은 2자 이상이어야 합니다").max(10, "닉네임은 10자 이하여야 합니다"),
-    email: z.string().min(1, "이메일을 입력해주세요").email("올바른 이메일 형식이 아닙니다"),
+    name: z.string().min(2, VALIDATION_ERRORS.name.min).max(10, VALIDATION_ERRORS.name.max),
+    email: z.string().min(1, VALIDATION_ERRORS.email.required).email(VALIDATION_ERRORS.email.invalid),
     password: z
       .string()
-      .regex(
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-        "8글자 이상, 영문, 숫자, 특수문자를 모두 포함해야 합니다.",
-      ),
-    passwordConfirm: z.string().min(1, "비밀번호를 다시 한 번 입력해주세요"),
-    regions: z.array(z.enum(REGION_VALUES)).min(1, "활동 지역을 선택해주세요"),
-    interestCategories: z.array(z.enum(CATEGORY_VALUES)).min(1, "관심 카테고리를 선택해주세요"),
+      .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, VALIDATION_ERRORS.password.requirements),
+    passwordConfirm: z.string().min(1, VALIDATION_ERRORS.password.confirmRequired),
+    regions: z.array(z.enum(REGION_VALUES)).min(1, VALIDATION_ERRORS.stepTwo.regionRequired),
+    interestCategories: z.array(z.enum(CATEGORY_VALUES)).min(1, VALIDATION_ERRORS.stepTwo.categoryRequired),
   })
   .refine((data) => data.password === data.passwordConfirm, {
-    message: "비밀번호가 일치하지 않습니다",
+    message: VALIDATION_ERRORS.password.notMatch,
     path: ["passwordConfirm"],
   });
 


### PR DESCRIPTION
## 🔢 관련 이슈
- close #26 

## 📌 작업 개요
회원가입 UI 및 유효성 검사 테스트 코드 추가

## 📝 작업 상세
### 1. 비밀번호 유효성 검사 추가
- 비밀번호가 8글자 이상 영문, 숫자, 특수문자를 포함하도록 수정

### 2. 테스트 코드 작성
- StepOne
- StepTwo
- SelectButton
- StepIndicator

### 3.  상수화 작업
- formLabels 및 messages 상수 파일 추가
- 유효성 검사 메시지 및 입력 필드 레이블을 코드 상수화

### 4. 패키지 추가
- @testing-library/user-event 추가 (^14.5.2)
- 사용자 이벤트 시뮬레이션을 위해 설치
