### PR TITLE
feat: 로그인 페이지 개발

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,12 @@
 import { clientAxios } from "@/lib/axios";
-import { SignUpFormData } from "@/types/auth";
+import { SignUpFormData, LoginFormData, LoginResponse } from "@/types/auth";
 
 export const signUpApi = async (formData: SignUpFormData) => {
   const { data } = await clientAxios.post("/api/auths/signup", formData);
+  return data;
+};
+
+export const loginApi = async (formData: LoginFormData) => {
+  const { data } = await clientAxios.post<LoginResponse>("/api/auths/signin", formData);
   return data;
 };

--- a/src/app/(auth)/_component/AuthLayout.tsx
+++ b/src/app/(auth)/_component/AuthLayout.tsx
@@ -4,7 +4,7 @@ interface AuthLayoutProps {
 
 export function AuthLayout({ children }: AuthLayoutProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center py-10">
+    <div className="flex min-h-[calc(100vh-80px)] items-center justify-center py-10">
       <div className="w-full max-w-lg rounded-2xl border-2 border-gray-100 bg-white px-4 py-12 drop-shadow-[0px_0px_10px_rgba(0,0,0,0.1)] sm:px-12">
         {children}
       </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,3 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { Form } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { FormFieldWrapper } from "@/components/common/FormFieldWrapper";
+import { Eye, EyeOff } from "lucide-react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema } from "@/schemas/auth";
+import { useLogin } from "@/queries/auth/useLogin";
+import { FORM_LABELS } from "@/constants/formLabels";
+import { AuthLayout } from "../_component/AuthLayout";
+
 export default function Login() {
-  return <div>Login</div>;
+  const [showPassword, setShowPassword] = useState(false);
+
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+    resolver: zodResolver(loginSchema),
+  });
+
+  const { mutate: login } = useLogin();
+
+  const onSubmit = (values: any) => {
+    login(values);
+  };
+
+  return (
+    <AuthLayout>
+      <h2 className="mb-8 text-center text-2xl font-bold">로그인</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormFieldWrapper
+            control={form.control}
+            name="email"
+            label={FORM_LABELS.email.label}
+            placeholder={FORM_LABELS.email.placeholder}
+          />
+          <FormFieldWrapper
+            control={form.control}
+            name="password"
+            label={FORM_LABELS.password.label}
+            renderContent={(field) => (
+              <div className="relative">
+                <Input
+                  type={showPassword ? "text" : "password"}
+                  placeholder={FORM_LABELS.password.placeholder}
+                  {...field}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500"
+                >
+                  {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+                </button>
+              </div>
+            )}
+          />
+          <div className="flex flex-col gap-2">
+            <Button type="submit" className="w-full">
+              로그인
+            </Button>
+            <Button className="w-full p-0" variant="outline">
+              <Link href="/signup" className="flex h-full w-full items-center justify-center">
+                회원가입
+              </Link>
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </AuthLayout>
+  );
 }

--- a/src/app/(auth)/signup/_component/StepOne.tsx
+++ b/src/app/(auth)/signup/_component/StepOne.tsx
@@ -19,7 +19,7 @@ export function StepOne({ form }: StepOneProps) {
 
   return (
     <>
-      <h1 className="mb-8 text-center text-2xl font-bold">회원가입</h1>
+      <h2 className="mb-8 text-center text-2xl font-bold">회원가입</h2>
       <FormFieldWrapper
         control={form.control}
         name="name"
@@ -76,7 +76,6 @@ export function StepOne({ form }: StepOneProps) {
           </div>
         )}
       />
-
       <div className="font-medium">
         이미 회원이신가요?
         <Link href="/login" className="pl-2 text-main underline">

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -10,6 +10,17 @@ export const clientAxios = axios.create({
   },
 });
 
+clientAxios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      Cookies.remove("accessToken");
+      Cookies.remove("tokenExpiresAt");
+    }
+    return Promise.reject(error);
+  },
+);
+
 clientAxios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = Cookies.get("accessToken");
   if (token) {
@@ -26,6 +37,20 @@ export const serverAxios = axios.create({
     Accept: "application/json",
   },
 });
+
+serverAxios.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response?.status === 401) {
+      const { cookies } = require("next/headers");
+      const cookieStore = cookies();
+
+      cookieStore.delete("accessToken");
+      cookieStore.delete("tokenExpiresAt");
+    }
+    return Promise.reject(error);
+  },
+);
 
 serverAxios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const { cookies } = require("next/headers");

--- a/src/queries/auth/useLogin.ts
+++ b/src/queries/auth/useLogin.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+import { loginApi } from "@/api/auth";
+import { useRouter } from "next/navigation";
+import Cookies from "js-cookie";
+import { toast } from "@/hooks/use-toast";
+
+export const useLogin = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: loginApi,
+    onSuccess: (data) => {
+      if (data.success) {
+        Cookies.set("accessToken", data.data.accessToken.token);
+        Cookies.set("tokenExpiresAt", String(data.data.accessToken.expiredAt));
+        router.push("/");
+      }
+    },
+    onError: (error: any) => {
+      toast({
+        variant: "destructive",
+        title: "로그인 실패",
+        description: error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
+        duration: 2000,
+      });
+    },
+  });
+};

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -6,6 +6,14 @@ import * as z from "zod";
 export const REGION_VALUES = REGIONS.map((r) => r.value) as [string, ...string[]];
 export const CATEGORY_VALUES = CATEGORIES.map((c) => c.value) as [string, ...string[]];
 
+export const loginSchema = z.object({
+  email: z.string().min(1, VALIDATION_ERRORS.email.required).email(VALIDATION_ERRORS.email.invalid),
+  password: z
+    .string()
+    .min(1, VALIDATION_ERRORS.password.requirements)
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, VALIDATION_ERRORS.password.requirements),
+});
+
 export const signUpSchema = z
   .object({
     name: z.string().min(2, VALIDATION_ERRORS.name.min).max(10, VALIDATION_ERRORS.name.max),
@@ -24,7 +32,7 @@ export const signUpSchema = z
 
 export type SignUpFormType = z.infer<typeof signUpSchema>;
 
-// 기본값 설정
+// 회원가입 기본값
 export const DEFAULT_SIGNUP_VALUES: SignUpFormData = {
   name: "",
   email: "",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,3 +13,23 @@ export interface SignUpFormData {
   regions: Region[];
   interestCategories: Category[];
 }
+
+export interface LoginFormData {
+  name: string;
+  email: string;
+}
+
+export interface LoginResponse {
+  success: boolean;
+  data: {
+    accessToken: {
+      token: string;
+      expiredAt: number;
+    };
+    email: string;
+    name: string;
+    profileImage: string;
+    regions: string[];
+    interestCategories: string[];
+  };
+}


### PR DESCRIPTION
## 🔢 관련 이슈
- close #33

## 📌 작업 개요
로그인 API 연동 및 로그인 페이지 개발

## 📝 작업 상세
### 1. 로그인 페이지 구현
- `src/app/(auth)/login/page.tsx`
- AuthLayout 공통 레이아웃 사용

### 2. API 연동
- loginApi 함수 추가
- useLogin 훅 생성
  - 로그인 성공 시:
    - accessToken과 tokenExpiresAt 쿠키 저장
    - router.push로 메인 페이지 이동
  - 로그인 실패 시:
    - toast 메시지로 에러 처리
- axios 401 에러 처리 (쿠키 삭제) 인터셉터 추가

### 3. 리팩토링 및 개선
- StepOne 컴포넌트에서 타이틀을 h1 → h2로 변경
- AuthLayout에서 min-h-screen 대신 min-h-[calc(100vh-80px)]를 적용하여 화면 높이 조정