### PR TITLE
feat: 모임 페이지 생성 및 카테고리 기능 추가

### DIFF
--- a/src/app/(main)/[category]/page.tsx
+++ b/src/app/(main)/[category]/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Suspense } from "react";
+import MoimPage from "../_component/MoimPage";
+
+export default function CategoryPage({ params }: { params: { category: string } }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MoimPage initialCategory={params.category.toUpperCase()} />
+    </Suspense>
+  );
+}

--- a/src/app/(main)/_component/MoimPage.tsx
+++ b/src/app/(main)/_component/MoimPage.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { HOME_CATEGORIES, SUB_CATEGORIES } from "@/constants/options";
+import Tabs from "@/components/common/Tabs";
+import Tags from "@/components/common/Tags";
+
+export type Category = "ALL" | "RECOMMENDED" | "CULTURE" | "FOOD" | "SPORTS" | "HOBBY" | "TRAVEL" | "STUDY" | "MEETING";
+
+interface MoimPageProps {
+  initialCategory?: string;
+}
+
+export default function MoimPage({ initialCategory = "ALL" }: MoimPageProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const [category, setCategory] = useState<Category>(() => {
+    const pathSegments = pathname.split("/");
+    const categoryFromPath = pathSegments[1]?.toUpperCase() || initialCategory;
+    return categoryFromPath as Category;
+  });
+  const [subCategory, setSubCategory] = useState<string>(() => searchParams.get("subCategory") || "all");
+
+  // URL 업데이트 함수
+  const updateURL = (newCategory: string, newSubCategory: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (newSubCategory !== "all") {
+      params.set("subCategory", newSubCategory);
+    } else {
+      params.delete("subCategory");
+    }
+
+    const query = params.toString();
+    router.push(`/${newCategory.toLowerCase()}${query ? `?${query}` : ""}`);
+  };
+
+  return (
+    <>
+      {/* Categories */}
+      <Tabs
+        tabs={HOME_CATEGORIES.map((cate) => ({
+          name: cate.label,
+          value: cate.value.toLowerCase(),
+        }))}
+        selectedValue={category.toLowerCase()}
+        onSelect={(value) => {
+          const newCategory = value.toUpperCase() as Category;
+          setCategory(newCategory);
+          updateURL(newCategory, "all");
+          setSubCategory("all");
+        }}
+      />
+      {/* Sub Categories */}
+      {category !== "ALL" && category !== "RECOMMENDED" && SUB_CATEGORIES[category] && (
+        <Tags
+          tags={[
+            { name: "전체", value: "all" }, // 공통 옵션 추가
+            ...SUB_CATEGORIES[category].map((subCate) => ({
+              name: subCate.label,
+              value: subCate.value.toLowerCase(),
+            })),
+          ]}
+          selectedValue={subCategory}
+          onSelect={(value) => {
+            setSubCategory(value);
+            updateURL(category, value);
+          }}
+          className="mt-8"
+        />
+      )}
+      {/* Filters */}
+    </>
+  );
+}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+import { Suspense } from "react";
 import MoimPage from "./_component/MoimPage";
 
 export default function Home() {
-  return <MoimPage />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MoimPage />
+    </Suspense>
+  );
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,3 +1,5 @@
+import MoimPage from "./_component/MoimPage";
+
 export default function Home() {
-  return <div>momoim</div>;
+  return <MoimPage />;
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import MoimPage from "./_component/MoimPage";
 
 export default function Home() {

--- a/src/app/[category]/page.tsx
+++ b/src/app/[category]/page.tsx
@@ -1,5 +1,0 @@
-import MoimPage from "../(main)/_component/MoimPage";
-
-export default function CategoryPage({ params }: { params: { category: string } }) {
-  return <MoimPage initialCategory={params.category.toUpperCase()} />;
-}

--- a/src/app/[category]/page.tsx
+++ b/src/app/[category]/page.tsx
@@ -1,0 +1,5 @@
+import MoimPage from "../(main)/_component/MoimPage";
+
+export default function CategoryPage({ params }: { params: { category: string } }) {
+  return <MoimPage initialCategory={params.category.toUpperCase()} />;
+}

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -1,24 +1,19 @@
-"use client";
-
-import sectionSlider from "@/lib/sectionSlider";
-import { usePathname, useRouter } from "next/navigation";
 import { useRef } from "react";
-
-interface Props {
-  tabs: Tab[];
-}
+import sectionSlider from "@/lib/sectionSlider";
 
 interface Tab {
   name: string;
   value: string;
-  path: string;
 }
 
-export default function Tabs({ tabs }: Props) {
+interface TabsProps {
+  tabs: Tab[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+}
+
+export default function Tabs({ tabs, selectedValue, onSelect }: TabsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
-  const path = usePathname();
-  const currentId = path.split("/").pop()?.split("?")[0] ?? "";
 
   return (
     <div
@@ -28,22 +23,20 @@ export default function Tabs({ tabs }: Props) {
         sectionSlider(e, containerRef);
       }}
       ref={containerRef}
-      className="flex w-full gap-4 overflow-auto px-6 scrollbar-hide"
+      className="flex w-full gap-4 overflow-auto font-semibold text-gray-500 scrollbar-hide"
     >
       {tabs.map((tab) => {
-        const isSelected = tab.value === currentId;
+        const isSelected = tab.value === selectedValue;
         return (
           <div key={tab.value} className="flex flex-col items-center">
             <button
               type="button"
-              onClick={() => {
-                router.push(tab.path);
-              }}
-              className={`whitespace-nowrap p-4 text-sm sm:text-base ${isSelected && "font-bold"} w-auto`}
+              onClick={() => onSelect(tab.value)}
+              className={`whitespace-nowrap p-4 text-sm sm:text-base ${isSelected && "text-gray-900"} w-auto`}
             >
               {tab.name}
             </button>
-            {isSelected && <div className="h-0.5 w-full bg-black" />}
+            {isSelected && <div className="h-0.5 w-full bg-gray-900" />}
           </div>
         );
       })}

--- a/src/components/common/Tags.tsx
+++ b/src/components/common/Tags.tsx
@@ -1,25 +1,21 @@
-"use client";
-
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Button } from "@/components/ui/button";
 import { useRef } from "react";
 import sectionSlider from "@/lib/sectionSlider";
-
-interface Props {
-  tags: Tag[];
-}
+import { cn } from "@/lib/utils";
 
 interface Tag {
   name: string;
   value: string;
 }
 
-export default function Tags({ tags }: Props) {
+interface TagsProps {
+  tags: Tag[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+  className?: string;
+}
+
+export default function Tags({ tags, selectedValue, onSelect, className }: TagsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
-  const path = usePathname();
-  const searchParams = useSearchParams();
-  const query = searchParams.get("sub");
 
   return (
     <div
@@ -29,23 +25,23 @@ export default function Tags({ tags }: Props) {
       onMouseDown={(e) => {
         sectionSlider(e, containerRef);
       }}
-      className="my-4 flex w-full cursor-grab gap-2 overflow-x-auto overflow-y-hidden whitespace-nowrap scrollbar-hide"
+      className={cn(
+        "my-4 flex w-full cursor-grab gap-2 overflow-x-auto overflow-y-hidden whitespace-nowrap font-medium scrollbar-hide",
+        className,
+      )}
     >
-      {tags?.map((tag) => {
-        return (
-          <Button
-            key={tag.value}
-            variant="secondary"
-            type="button"
-            onClick={() => {
-              router.push(`${path}?sub=${tag.value}`);
-            }}
-            className={`${tag.value.includes(query as string) ? "bg-gray-300 font-bold text-main" : "bg-gray-100"} rounded-xl px-4 py-3 text-sm sm:text-base`}
-          >
-            {tag.name}
-          </Button>
-        );
-      })}
+      {tags?.map((tag) => (
+        <button
+          type="button"
+          key={tag.value}
+          onClick={() => onSelect(tag.value)}
+          className={`${
+            tag.value.toLowerCase() === selectedValue ? "bg-gray-250 text-main" : "bg-gray-100"
+          } rounded-xl px-4 py-3 text-sm sm:text-base`}
+        >
+          {tag.name}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-3",
+        default: "h-12 px-4 py-3",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -1,5 +1,4 @@
-export const REGIONS = [
-  { value: "ALL", label: "전체" },
+const COMMON_REGIONS = [
   { value: "SEOUL", label: "서울" },
   { value: "BUSAN", label: "부산" },
   { value: "DAEGU", label: "대구" },
@@ -19,8 +18,15 @@ export const REGIONS = [
   { value: "JEJU", label: "제주" },
 ] as const;
 
-export const CATEGORIES = [
-  { value: "ALL", label: "전체" },
+export const REGIONS = [{ value: "ALL", label: "전체" }, ...COMMON_REGIONS] as const;
+
+export const LOCATIONS = [
+  { value: "ALL", label: "모든 지역" },
+  { value: "ONLINE", label: "온라인" },
+  ...COMMON_REGIONS,
+] as const;
+
+export const COMMON_CATEGORIES = [
   { value: "CULTURE", label: "문화/예술" },
   { value: "FOOD", label: "푸드" },
   { value: "SPORTS", label: "스포츠" },
@@ -29,6 +35,69 @@ export const CATEGORIES = [
   { value: "STUDY", label: "스터디" },
   { value: "MEETING", label: "미팅" },
 ] as const;
+
+export const CATEGORIES = [{ value: "ALL", label: "전체" }, ...COMMON_CATEGORIES] as const;
+
+export const HOME_CATEGORIES = [
+  { value: "ALL", label: "전체" },
+  { value: "RECOMMEND", label: "추천" },
+  ...COMMON_CATEGORIES,
+] as const;
+
+export const SUB_CATEGORIES = {
+  CULTURE: [
+    { value: "MOVIE", label: "영화" },
+    { value: "CONCERT", label: "콘서트" },
+    { value: "EXHIBITION", label: "전시" },
+    { value: "PERFORMANCE", label: "공연" },
+  ],
+  FOOD: [
+    { value: "RESTAURANT", label: "맛집투어" },
+    { value: "COOKING", label: "요리" },
+    { value: "BAKING", label: "베이킹" },
+  ],
+  SPORTS: [
+    { value: "SOCCER", label: "축구" },
+    { value: "BASKETBALL", label: "농구" },
+    { value: "BASEBALL", label: "야구" },
+    { value: "BIKE", label: "자전거" },
+    { value: "GOLF", label: "골프" },
+    { value: "RUNNING", label: "러닝" },
+    { value: "FITNESS", label: "헬스" },
+    { value: "DIET", label: "다이어트" },
+    { value: "YOGA", label: "요가" },
+    { value: "PILATES", label: "필라테스" },
+    { value: "SWIMMING", label: "수영" },
+  ],
+  HOBBY: [
+    { value: "PET", label: "반려동물" },
+    { value: "BOOK", label: "독서" },
+    { value: "MUSIC", label: "음악" },
+    { value: "PHOTO", label: "사진" },
+    { value: "GAME", label: "게임" },
+    { value: "DANCE", label: "댄스" },
+    { value: "CRAFTING", label: "공예" },
+    { value: "MEDIA", label: "미디어" },
+    { value: "SUB_CULTURE", label: "서브컬쳐" },
+  ],
+  TRAVEL: [
+    { value: "HIKING", label: "등산" },
+    { value: "FISHING", label: "낚시" },
+    { value: "CAMPING", label: "캠핑" },
+    { value: "DOMESTIC", label: "국내여행" },
+    { value: "INTERNATIONAL", label: "해외여행" },
+  ],
+  STUDY: [
+    { value: "LANGUAGES", label: "외국어" },
+    { value: "FINANCE", label: "재테크" },
+    { value: "SELF_DEVELOP", label: "자기계발" },
+  ],
+  MEETING: [
+    { value: "LOVE", label: "연애" },
+    { value: "COFFEE_CHAT", label: "커피챗" },
+    { value: "INTERVIEW", label: "면접/인터뷰" },
+  ],
+};
 
 export const GATHERING_SORT_OPTIONS = [
   { value: "UPDATE_AT", label: "최신순" },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,7 +62,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-gray-900;
   }
 }
 


### PR DESCRIPTION
## 🔢 관련 이슈
#42 

## 📌 작업 개요
메인 홈페이지 카테고리 부분 UI 구현

## 📝 작업 상세
- `MoimPage` 컴포넌트 추가
  - 상위 카테고리 및 서브 카테고리 구현 (`Tabs`, `Tags` 컴포넌트 사용)
- `Tabs`, `Tags` 컴포넌트 리팩토링
  - 선택된 값(`selectedValue`)과 이벤트 핸들러(`onSelect`)를 통해 제어 가능하도록 수정
- 상수 파일(`options.ts`) 정리
  - 공통 지역(`COMMON_REGIONS`) 및 카테고리(`COMMON_CATEGORIES`) 분리
  - `REGIONS`, `LOCATIONS`, `CATEGORIES`, `HOME_CATEGORIES` 생성 시 공통 데이터 활용
- 글로벌 스타일 개선
  - 기본 텍스트 색상 변경: `text-gray-900`
  - shadcn 기본 버튼 높이 h-12로 조정