### PR TITLE
feat: 모임 만들기 버튼 생성

### DIFF
--- a/src/app/(main)/_component/MoimGrid.tsx
+++ b/src/app/(main)/_component/MoimGrid.tsx
@@ -7,7 +7,7 @@ import { useMoimList } from "@/queries/gatherings/useMoimList";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { EmptyState } from "@/components/common/EmptyState";
 import { useRouter } from "next/navigation";
-import { LOCATIONS, SORT_ORDERS, SORTS } from "@/constants/gatherings";
+import { LOCATIONS } from "@/constants/gatherings";
 
 interface MoimGridProps {
   category: string;

--- a/src/app/(main)/liked/page.tsx
+++ b/src/app/(main)/liked/page.tsx
@@ -1,3 +1,0 @@
-export default function Liked() {
-  return <div>Liked</div>;
-}

--- a/src/app/(main)/reviews/page.tsx
+++ b/src/app/(main)/reviews/page.tsx
@@ -1,3 +1,0 @@
-export default function Reviews() {
-  return <div>Reviews</div>;
-}

--- a/src/app/_component/AuthSection.tsx
+++ b/src/app/_component/AuthSection.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useUser } from "@/queries/auth/useUser";
+import AuthButtons from "./AuthButtons";
+import ProfileButton from "./ProfileButton";
+
+export default function AuthSection() {
+  const { data: user, isLoading } = useUser();
+
+  if (isLoading) return null;
+
+  return <ul className="flex items-center gap-4">{user ? <ProfileButton user={user} /> : <AuthButtons />}</ul>;
+}

--- a/src/app/_component/CreateMoimButton.tsx
+++ b/src/app/_component/CreateMoimButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useUser } from "@/queries/auth/useUser";
+import { Plus } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+
+const CREATE_GATHERING_URL = "/gatherings/create";
+
+export default function CreateMoimButton() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: user, isLoading } = useUser();
+
+  if (isLoading || !user || pathname === CREATE_GATHERING_URL) return null;
+
+  return (
+    <button
+      type="button"
+      className="group fixed bottom-6 right-6 z-10 flex h-14 w-14 items-center justify-center rounded-full bg-main drop-shadow-[0_0_10px_rgba(0,0,0,0.2)] transition-all duration-300 ease-in-out hover:w-36"
+      onClick={() => router.push(CREATE_GATHERING_URL)}
+    >
+      <Plus className="h-6 w-6 text-white" />
+      <span className="w-0 overflow-hidden whitespace-nowrap font-semibold text-white transition-all duration-300 group-hover:w-24">
+        모임 만들기
+      </span>
+    </button>
+  );
+}

--- a/src/app/_component/Header.tsx
+++ b/src/app/_component/Header.tsx
@@ -3,20 +3,13 @@
 import React from "react";
 import Logo from "@/assets/svg/logo.svg";
 import Link from "next/link";
-import { useUser } from "@/queries/auth/useUser";
-import AuthButtons from "./AuthButtons";
-import ProfileButton from "./ProfileButton";
+import dynamic from "next/dynamic";
+
+const AuthSection = dynamic(() => import("./AuthSection"), {
+  ssr: false, // 클라이언트에서만 렌더링하도록 설정
+});
 
 export default function Header() {
-  const { data: user, isLoading } = useUser();
-
-  const renderAuthSection = () => {
-    if (isLoading) {
-      return null;
-    }
-    return user ? <ProfileButton user={user} /> : <AuthButtons />;
-  };
-
   return (
     <header className="fixed z-50 w-full bg-white">
       <nav className="mx-auto flex h-[80px] max-w-screen-xl items-center justify-between px-4">
@@ -25,7 +18,7 @@ export default function Header() {
             <Logo aria-label="Website Logo" />
           </Link>
         </h1>
-        <ul className="flex items-center gap-4">{renderAuthSection()}</ul>
+        <AuthSection />
       </nav>
     </header>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import TanStackProvider from "@/lib/TanStackProvider";
 import { Toaster } from "@/components/ui/toaster";
 import Header from "./_component/Header";
+import CreateMoimButton from "./_component/CreateMoimButton";
 
 const pretendard = localFont({
   src: "../assets/fonts/PretendardVariable.woff2",
@@ -31,6 +32,7 @@ export default function RootLayout({
         <TanStackProvider>
           <Header />
           <main className="mx-auto max-w-screen-xl px-4 pt-[80px]">{children}</main>
+          <CreateMoimButton />
           <Toaster />
           <SpeedInsights />
         </TanStackProvider>

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 
 interface EmptyStateProps {
@@ -5,11 +6,12 @@ interface EmptyStateProps {
   description: string; // 설명 텍스트
   actionText?: string; // 버튼 텍스트 (옵션)
   onAction?: () => void; // 버튼 클릭 핸들러 (옵션)
+  className?: string;
 }
 
-export function EmptyState({ title, description, actionText, onAction }: EmptyStateProps) {
+export function EmptyState({ title, description, actionText, onAction, className }: EmptyStateProps) {
   return (
-    <div className="flex min-h-96 flex-col items-center justify-center py-16">
+    <div className={cn("flex min-h-96 flex-col items-center justify-center", className)}>
       <p className="text-gray-700">{title}</p>
       <p className="text-gray-700">{description}</p>
       {actionText && onAction && (

--- a/src/lib/TanStackProvider.tsx
+++ b/src/lib/TanStackProvider.tsx
@@ -31,7 +31,7 @@ export default function TanStackProvider({ children }: { children: ReactNode }) 
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      <ReactQueryDevtools initialIsOpen={false} />
+      <ReactQueryDevtools buttonPosition="bottom-left" initialIsOpen={false} />
     </QueryClientProvider>
   );
 }

--- a/src/queries/auth/useUser.ts
+++ b/src/queries/auth/useUser.ts
@@ -1,12 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { getUser } from "@/api/user";
+import Cookies from "js-cookie";
 
 export const useUser = () => {
+  const accessToken = Cookies.get("accessToken");
+
   return useQuery({
     queryKey: ["user"],
     queryFn: getUser,
     staleTime: Infinity,
     retry: 0,
+    enabled: !!accessToken, // 로그인 상태에서만 쿼리 실행
     placeholderData: (previousData) => previousData,
   });
 };


### PR DESCRIPTION
## 🔢 관련 이슈
- #42 

## 📌 작업 개요
- 모임 만들기 버튼 생성
- 로그인 상태에서만 useUser 훅이 데이터를 가져오도록 수정

## 📝 작업 상세
#### 1. 모임 만들기 버튼 구현
- 로그인 상태에서만 버튼이 렌더링되도록 조건부 렌더링 추가
- 현재 URL이 `/gatherings/create`일 경우 버튼을 숨김 처리
- React Query Devtools 버튼과 위치가 겹쳐서 Devtools 버튼 위치를 하단 왼쪽으로 이동

#### 2. 로그인 상태에서만 useUser 쿼리 실행
- React Query의 enabled 옵션을 활용하여 accessToken이 존재하는 경우에만 데이터를 요청
- 불필요한 API 호출 방지 및 403 Forbidden 오류 해결
- Header 컴포넌트와 인증 섹션 동적 분리
  - Hydration 문제 해결을 위해 클라이언트에서만 AuthSection 렌더링
  - AuthSection 컴포넌트를 동적으로 dynamic import하여 서버사이드 렌더링(SSR)을 비활성화


## 🎸 기타 참고 사항
- [dynamic import 참고 문서](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-no-ssr)
- emptyState 컴포넌트에 className props추가
- app 라우터 미사용 폴더 삭제