### PR TITLE
fix: 모임 생성 시 썸네일 이미지

### DIFF
--- a/src/app/(main)/gatherings/create/_component/AddressInput.test.tsx
+++ b/src/app/(main)/gatherings/create/_component/AddressInput.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useForm } from "react-hook-form";
+import { DEFAULT_GATHERING_CREATE_VALUES, gatheringCreateSchema } from "@/schemas/gatheringCreate";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form } from "@/components/ui/form";
+import { FormFieldWrapper } from "@/components/common/FormFieldWrapper";
+import AddressInput from "./AddressInput";
+
+const mockChange = jest.fn();
+const mockOnComplete = jest.fn();
+const mockCloseModal = jest.fn();
+
+function AddressInputComponent() {
+  const form = useForm({
+    resolver: zodResolver(gatheringCreateSchema),
+    defaultValues: DEFAULT_GATHERING_CREATE_VALUES,
+  });
+
+  form.setValue = mockOnComplete;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <FormFieldWrapper
+          control={form.control}
+          name="address"
+          label="주소"
+          placeholder="모임을 진행할 주소를 입력해주세요."
+          customStyle="border-gray-500 text-gray-700 font-medium"
+          renderContent={(field) => <AddressInput form={form} field={{ ...field, onChange: mockChange }} />}
+        />
+      </form>
+    </Form>
+  );
+}
+
+jest.mock("@/store/modalStore", () => ({
+  useModalStore: () => ({
+    isOpen: true,
+    openModal: jest.fn(),
+    closeModal: mockCloseModal,
+  }),
+}));
+
+let mockProps: any;
+jest.mock("react-daum-postcode", () => {
+  return jest.fn().mockImplementation((props) => {
+    mockProps = props;
+    return <div data-testid="daum-postcode" />;
+  });
+});
+
+describe("AddressInput 컴포넌트", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProps = null;
+    render(<AddressInputComponent />);
+  });
+
+  it("input을 클릭하면 도로명 주소를 검색할 수 있는 모달이 open 되어야한다.", () => {
+    const addressInput = screen.getByPlaceholderText("클릭을 통해 주소를 검색해주세요.");
+    expect(addressInput).toBeInTheDocument();
+
+    fireEvent.click(addressInput);
+    expect(addressInput).toHaveAttribute("data-state", "open");
+
+    const postcode = screen.getByTestId("daum-postcode");
+    expect(postcode).toBeInTheDocument();
+  });
+
+  describe("도로명 주소 검색 후 선택 시 조건에 따른 location 값 설정", () => {
+    beforeEach(() => {
+      const addressInput = screen.getByPlaceholderText("클릭을 통해 주소를 검색해주세요.");
+      fireEvent.click(addressInput);
+    });
+
+    it("sidoEnglish에 si가 포함된 경우 포멧팅해야 합니다.", () => {
+      mockProps.onComplete({ address: "서울시 동대문구", sidoEnglish: "seoul-si" });
+
+      expect(mockOnComplete).toHaveBeenCalledWith("location", "SEOUL");
+      expect(mockChange).toHaveBeenCalledWith("서울시 동대문구");
+    });
+
+    it("sidoEnglish에 do가 포함된 경우 포멧팅해야 합니다.", () => {
+      mockProps.onComplete({ address: "경기도 성남시", sidoEnglish: "gyeonggi-do" });
+
+      expect(mockOnComplete).toHaveBeenCalledWith("location", "GYEONGGI");
+      expect(mockChange).toHaveBeenCalledWith("경기도 성남시");
+    });
+
+    it("sidoEnglish의 포멧팅 조건에 걸리지 않으면 대문자로만 변환되어야 합니다.", () => {
+      mockProps.onComplete({ address: "제주특별자치도 제주시", sidoEnglish: "jeju" });
+
+      expect(mockOnComplete).toHaveBeenCalledWith("location", "JEJU");
+      expect(mockChange).toHaveBeenCalledWith("제주특별자치도 제주시");
+    });
+  });
+
+  it("상세주소를 입력하면 detailAddress 값이 업데이트 되어야합니다.", () => {
+    const detailAddressInput = screen.getByPlaceholderText("상세주소를 입력해주세요.");
+    expect(detailAddressInput).toBeInTheDocument();
+
+    fireEvent.change(detailAddressInput, { target: { value: "중앙 공원" } });
+
+    expect(mockOnComplete).toHaveBeenCalledWith("detailAddress", "중앙 공원");
+  });
+
+  it("모달이 닫힐 때 closeModal이 호출되어야 합니다.", () => {
+    const addressInput = screen.getByPlaceholderText("클릭을 통해 주소를 검색해주세요.");
+    fireEvent.click(addressInput);
+    expect(addressInput).toHaveAttribute("data-state", "open");
+
+    mockProps.onClose("COMPLETE_CLOSE");
+    expect(mockCloseModal).toHaveBeenCalled();
+  });
+});

--- a/src/app/(main)/gatherings/create/_component/FormOnlineAddress.test.tsx
+++ b/src/app/(main)/gatherings/create/_component/FormOnlineAddress.test.tsx
@@ -1,0 +1,65 @@
+import { DEFAULT_GATHERING_CREATE_VALUES, gatheringCreateSchema } from "@/schemas/gatheringCreate";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FormFieldWrapper } from "@/components/common/FormFieldWrapper";
+import { Form } from "@/components/ui/form";
+import { ONLINE_PLATFORM } from "@/constants/options";
+import FormOnlineAddress from "./FormOnlineAddress";
+
+const mockChange = jest.fn();
+
+function FormOnlineAddressComponent() {
+  const form = useForm({
+    resolver: zodResolver(gatheringCreateSchema),
+    defaultValues: DEFAULT_GATHERING_CREATE_VALUES,
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <FormFieldWrapper
+          control={form.control}
+          name="onlinePlatform"
+          label="플랫폼"
+          renderContent={(field) => <FormOnlineAddress form={form} field={{ ...field, onChange: mockChange }} />}
+        />
+      </form>
+    </Form>
+  );
+}
+
+describe("FormOnlineAddress 컴포넌트", () => {
+  beforeEach(() => {
+    render(<FormOnlineAddressComponent />);
+  });
+
+  it("온라인 플랫폼에 대한 select가 랜더링 되어야한다.", () => {
+    const onlineSelcet = screen.getByRole("combobox");
+    expect(onlineSelcet).toBeInTheDocument();
+  });
+
+  it("select 영역 클릭 시 온라인 플랫폼 요소들이 랜더링 되어야한다.", async () => {
+    const onlineSelcet = screen.getByRole("combobox");
+    fireEvent.click(onlineSelcet);
+
+    expect(onlineSelcet).toHaveAttribute("aria-expanded", "true");
+
+    const onlinePlatformSection = screen.getByTestId("onlinePlatform-section");
+    ONLINE_PLATFORM.forEach(({ label }) => {
+      expect(within(onlinePlatformSection).getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("온라인 플랫폼을 선택하면 onchange가 호출되어야 한다.", () => {
+    const onlineSelect = screen.getByRole("combobox");
+    fireEvent.click(onlineSelect);
+
+    const selectPlatform = screen.getByRole("option", { name: ONLINE_PLATFORM[0].label });
+    fireEvent.click(selectPlatform);
+
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith(ONLINE_PLATFORM[0].value);
+  });
+});

--- a/src/app/(main)/gatherings/create/_component/FormTypeButton.test.tsx
+++ b/src/app/(main)/gatherings/create/_component/FormTypeButton.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import FormTypeButton from "./FormTypeButton";
+
+describe("FormTypeButton 컴포넌트", () => {
+  const mockChange = jest.fn();
+
+  beforeEach(() => {
+    render(<FormTypeButton activeValue buttonText="정기 모임" value="정기 모임" onChange={mockChange} />);
+  });
+
+  it("button 요소가 랜더링 되어야한다.", () => {
+    const formTypeButton = screen.getByRole("button", { name: "정기 모임" });
+    expect(formTypeButton).toBeInTheDocument();
+  });
+
+  it("버튼을 클릭하면 onChagne가 호출되고 값이 정확히 호출되어야 한다.", () => {
+    const formTypeButton = screen.getByRole("button", { name: "정기 모임" });
+    fireEvent.click(formTypeButton);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/app/(main)/gatherings/create/_component/GatheringUploadImage.test.tsx
+++ b/src/app/(main)/gatherings/create/_component/GatheringUploadImage.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FormFieldWrapper } from "@/components/common/FormFieldWrapper";
+import { Form } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { DEFAULT_GATHERING_CREATE_VALUES, gatheringCreateSchema } from "@/schemas/gatheringCreate";
+import { ImageUploadApi } from "@/api/imageFile";
+import GatheringUploadImage from "./GatheringUploadImage";
+
+const mockChange = jest.fn();
+
+function ImageUploadComponent() {
+  const form = useForm({
+    resolver: zodResolver(gatheringCreateSchema),
+    defaultValues: DEFAULT_GATHERING_CREATE_VALUES,
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <FormFieldWrapper
+          control={form.control}
+          name="image"
+          type="text"
+          label="대표 이미지"
+          renderContent={(field) => <GatheringUploadImage form={form} field={{ ...field, onChange: mockChange }} />}
+        />
+      </form>
+    </Form>
+  );
+}
+
+jest.mock("@/api/imageFile", () => ({
+  ImageUploadApi: jest.fn(),
+}));
+
+describe("GatheringUploadImage 컴포넌트", () => {
+  beforeEach(() => {
+    render(<ImageUploadComponent />);
+  });
+
+  it("이미지 변경 버튼과 초기화 버튼이 랜더링되어 있어야한다.", () => {
+    expect(screen.getByText("이미지 변경")).toBeInTheDocument();
+    expect(screen.getByText("초기화")).toBeInTheDocument();
+  });
+
+  it("이미지 변경 버튼을 클릭하면 파일을 선택하고 업로드 api를 호출해야한다.", async () => {
+    const file = new Blob(["test file"], { type: "image/png" });
+    const fileList = { 0: file, length: 1 };
+    const mockImageUrl = "https://example.com/testImage.png";
+    (ImageUploadApi as jest.Mock).mockResolvedValue(mockImageUrl);
+
+    fireEvent.click(screen.getByText("이미지 변경"));
+    fireEvent.change(screen.getByTestId("file-input"), { target: { files: fileList } });
+
+    await waitFor(() => {
+      expect(ImageUploadApi).toHaveBeenCalledTimes(1);
+      expect(mockChange).toHaveBeenCalledWith(mockImageUrl);
+    });
+  });
+
+  it("초기화 버튼을 클릭하면 값이 null로 변경되어야한다.", () => {
+    fireEvent.click(screen.getByText("초기화"));
+
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
+++ b/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
@@ -39,7 +39,7 @@ export default function GatheringUploadImage({ form, field }: FormFieldProps) {
       </div>
       <div className="flex w-full gap-2">
         <div className="relative w-1/2">
-          <input type="file" ref={inputRef} onChange={handleGetImage} hidden />
+          <input type="file" ref={inputRef} onChange={handleGetImage} hidden data-testid="file-input" />
           <Button
             type="button"
             size="lg"

--- a/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
+++ b/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
@@ -22,7 +22,7 @@ export default function GatheringUploadImage({ form, field }: FormFieldProps) {
   };
 
   const handleImageReset = () => {
-    field.onChange("");
+    field.onChange(null);
   };
 
   return (

--- a/src/schemas/gatheringCreate.ts
+++ b/src/schemas/gatheringCreate.ts
@@ -18,7 +18,7 @@ export const gatheringCreateSchema = z
   .object({
     name: z.string().min(2, "모임 제목은 2글자 이상이어야 합니다").max(25, "모임 제목은 25글자 이하여야 합니다."),
     isPeriodic: z.boolean(),
-    image: z.string(),
+    image: z.string().nullable(),
     category: z.enum(CATEGORY_VALUES, { message: "카테고리를 선택해주세요." }),
     subCategory: z.enum(SUB_CATEGORIES_VALUES, { message: "서브 카테고리를 선택해주세요." }),
     location: z.string().optional(),
@@ -48,7 +48,7 @@ export type GatheringCreateFormType = z.infer<typeof gatheringCreateSchema>;
 export const DEFAULT_GATHERING_CREATE_VALUES: GatheringCreateFormData = {
   name: "",
   isPeriodic: false,
-  image: "",
+  image: null,
   category: COMMON_CATEGORIES[0].value,
   subCategory: "",
   location: "",

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -5,7 +5,7 @@ export type CategoryKey = (typeof COMMON_CATEGORIES)[number]["value"];
 export interface GatheringCreateFormData {
   name: string;
   isPeriodic: boolean;
-  image: string;
+  image: string | null;
   category: string;
   subCategory: string | string[];
   location: string;

--- a/src/types/common/formFieldprops.ts
+++ b/src/types/common/formFieldprops.ts
@@ -5,6 +5,6 @@ export interface FormFieldProps {
   form: UseFormReturn<GatheringCreateFormData>;
   field: {
     value: string;
-    onChange: (value: string) => void;
+    onChange: (value: string | null) => void;
   };
 }


### PR DESCRIPTION
## 🔢 관련 이슈

> 이슈번호를 입력해주세요. ex) #001

- #13 

## 📌 작업 개요

> 간략하게 작업한 내용을 작성해주세요.

- 모임 생성 시 썸네일 이미지 없을 경우 null 처리
- 모임 생성 컴포넌트 테스트 코드 작성

## 📝 작업 상세

> 작업한 내용을 상세하게 작성해주세요. (작성 후 하단 이미지 첨부가능)

- 모임 생성할때  썸네일 이미지가 없는경우 기본 이미지가 들어가면서 데이터 값이 "" 빈 스트링 값으로 저장되는 부분을 null로 통일하기로 함
- 모임 생성 컴포넌트 테스트 코드 작성
  - AddressInput
  - FormOnlineAddress
  - FormTypeButton
  - GatheringUploadImage

## 🎸 기타 참고 사항

> (선택) 참고할 자료나 코드리뷰 할때 특정 코드부분 자세히 봐주면 좋겠다는 사항을 작성해주세요.
