### PR TITLE
feat: 미들웨어 추가 및 인증 관련 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:https": "next dev -H local.momoim.co.kr -p 3000 --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -10,3 +10,8 @@ export const loginApi = async (formData: LoginFormData) => {
   const { data } = await clientAxios.post<LoginResponse>("/api/auths/signin", formData);
   return data;
 };
+
+export const logoutApi = async () => {
+  const { data } = await clientAxios.post("/api/auths/logout");
+  return data;
+};

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,8 +1,4 @@
-interface AuthLayoutProps {
-  children: React.ReactNode;
-}
-
-export function AuthLayout({ children }: AuthLayoutProps) {
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-[calc(100vh-80px)] items-center justify-center py-10">
       <div className="w-full max-w-lg rounded-2xl border-2 border-gray-100 bg-white px-4 py-12 drop-shadow-base sm:px-12">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -12,7 +12,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { loginSchema } from "@/schemas/auth";
 import { useLogin } from "@/queries/auth/useLogin";
 import { FORM_LABELS } from "@/constants/formLabels";
-import { AuthLayout } from "../_component/AuthLayout";
 
 export default function Login() {
   const [showPassword, setShowPassword] = useState(false);
@@ -32,7 +31,7 @@ export default function Login() {
   };
 
   return (
-    <AuthLayout>
+    <>
       <h2 className="mb-8 text-center text-2xl font-bold">로그인</h2>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -75,6 +74,6 @@ export default function Login() {
           </div>
         </form>
       </Form>
-    </AuthLayout>
+    </>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -5,41 +5,34 @@ import { Button } from "@/components/ui/button";
 import { StepOne } from "./_component/StepOne";
 import { StepTwo } from "./_component/StepTwo";
 import { StepIndicator } from "./_component/StepIndicator";
-import { AuthLayout } from "../_component/AuthLayout";
 import { useSignUpForm } from "./hooks/useSignUpForm";
 
 export default function SignUp() {
   const { form, step, duplicateChecked, setDuplicateChecked, handleSubmit } = useSignUpForm();
 
   return (
-    <AuthLayout>
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-          {step === 1 ? (
-            <StepOne checked={duplicateChecked} setChecked={setDuplicateChecked} form={form} />
-          ) : (
-            <StepTwo form={form} />
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        {step === 1 ? (
+          <StepOne checked={duplicateChecked} setChecked={setDuplicateChecked} form={form} />
+        ) : (
+          <StepTwo form={form} />
+        )}
+        <StepIndicator steps={2} currentStep={step} />
+        <div className="space-y-4">
+          <Button type="submit" className="h-12 w-full">
+            {step === 1 ? "다음으로" : "확인"}
+          </Button>
+          {step === 2 && (
+            <div className="text-center">
+              다음에 할게요.
+              <button type="button" onClick={form.handleSubmit(handleSubmit)} className="pl-2 text-gray-500 underline">
+                건너뛰기
+              </button>
+            </div>
           )}
-          <StepIndicator steps={2} currentStep={step} />
-          <div className="space-y-4">
-            <Button type="submit" className="h-12 w-full">
-              {step === 1 ? "다음으로" : "확인"}
-            </Button>
-            {step === 2 && (
-              <div className="text-center">
-                다음에 할게요.
-                <button
-                  type="button"
-                  onClick={form.handleSubmit(handleSubmit)}
-                  className="pl-2 text-gray-500 underline"
-                >
-                  건너뛰기
-                </button>
-              </div>
-            )}
-          </div>
-        </form>
-      </Form>
-    </AuthLayout>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/src/app/_component/ProfileButton.tsx
+++ b/src/app/_component/ProfileButton.tsx
@@ -4,10 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import DefaultProfile from "@/assets/svg/default-profile.svg";
-import Cookies from "js-cookie";
-import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 import { User } from "@/types/auth";
+import { useLogout } from "@/queries/auth/useLogout";
 
 interface ProfileButtonProps {
   user: User;
@@ -16,17 +14,13 @@ interface ProfileButtonProps {
 export default function ProfileButton({ user }: ProfileButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const popoverRef = useRef<HTMLLIElement>(null);
-  const router = useRouter();
-  const queryClient = useQueryClient();
+
+  const { mutate: logout } = useLogout();
 
   const closePopover = () => setIsOpen(false);
 
   const handleLogout = async () => {
-    Cookies.remove("accessToken");
-    Cookies.remove("tokenExpiresAt");
-    queryClient.setQueryData(["user"], null);
-    queryClient.invalidateQueries({ queryKey: ["user"] });
-    router.push("/");
+    logout();
     closePopover();
   };
 

--- a/src/lib/TanStackProvider.tsx
+++ b/src/lib/TanStackProvider.tsx
@@ -10,6 +10,7 @@ function makeQueryClient() {
       queries: {
         staleTime: 60 * 1000,
         refetchOnWindowFocus: false,
+        retry: 1,
       },
     },
   });

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,9 +1,16 @@
-import axios, { InternalAxiosRequestConfig } from "axios";
+import { toast } from "@/hooks/use-toast";
+import { LoginResponse } from "@/types/auth";
+import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 import Cookies from "js-cookie";
+
+interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
+  retryAttempted?: boolean;
+}
 
 // 클라이언트용 axios 인스턴스
 export const clientAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
@@ -12,19 +19,61 @@ export const clientAxios = axios.create({
 
 clientAxios.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      Cookies.remove("accessToken");
-      Cookies.remove("tokenExpiresAt");
+  async (error: AxiosError) => {
+    const originalRequest = error.config as ExtendedAxiosRequestConfig;
+
+    // 로그아웃 API는 토큰 검증 없이 처리
+    if (originalRequest.url === "/api/auths/logout") {
+      return Promise.reject(error);
     }
+
+    if (axios.isAxiosError(error) && error.response) {
+      const { status } = error.response;
+
+      if (status === 401 && !originalRequest.retryAttempted) {
+        originalRequest.retryAttempted = true;
+
+        try {
+          const { data } = await clientAxios.post<LoginResponse>("/api/auths/refresh");
+          const { accessToken } = data.data;
+
+          Cookies.set("accessToken", accessToken.token, {
+            secure: true,
+            sameSite: "lax",
+          });
+          originalRequest.headers.Authorization = `Bearer ${accessToken.token}`;
+          return await clientAxios(originalRequest);
+        } catch (refreshError) {
+          try {
+            await clientAxios.post("/api/auths/logout");
+          } catch (logoutError) {
+            toast({
+              variant: "destructive",
+              title: "로그아웃 실패",
+              description: "로그아웃 처리 중 오류가 발생했습니다",
+              duration: 2000,
+            });
+          } finally {
+            Cookies.remove("accessToken");
+            window.location.href = "/login";
+          }
+          return Promise.reject(refreshError);
+        }
+      }
+    }
+
     return Promise.reject(error);
   },
 );
 
 clientAxios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-  const token = Cookies.get("accessToken");
-  if (token) {
-    config.headers.set("Authorization", `Bearer ${token}`);
+  if (config.url === "/api/auths/logout" || config.url === "/api/auths/refresh") {
+    return config;
+  }
+
+  const accessToken = Cookies.get("accessToken");
+  if (accessToken) {
+    config.headers.set("Authorization", `Bearer ${accessToken}`);
   }
   return config;
 });
@@ -32,6 +81,7 @@ clientAxios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
 // 서버용 axios 인스턴스
 export const serverAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
@@ -44,9 +94,7 @@ serverAxios.interceptors.response.use(
     if (error.response?.status === 401) {
       const { cookies } = require("next/headers");
       const cookieStore = cookies();
-
       cookieStore.delete("accessToken");
-      cookieStore.delete("tokenExpiresAt");
     }
     return Promise.reject(error);
   },
@@ -55,10 +103,10 @@ serverAxios.interceptors.response.use(
 serverAxios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const { cookies } = require("next/headers");
   const cookieStore = cookies();
-  const token = cookieStore.get("accessToken")?.value;
+  const accessToken = cookieStore.get("accessToken")?.value;
 
-  if (token) {
-    config.headers.set("Authorization", `Bearer ${token}`);
+  if (accessToken) {
+    config.headers.set("Authorization", `Bearer ${accessToken}`);
   }
   return config;
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get("accessToken");
+
+  const { pathname } = request.nextUrl;
+
+  // /mypage 접근 제어
+  if (pathname.startsWith("/mypage")) {
+    if (!accessToken) {
+      return NextResponse.redirect(new URL("/login", request.nextUrl.origin));
+    }
+  }
+
+  // /login 및 /signup 접근 제어
+  if (pathname.startsWith("/login") || pathname.startsWith("/signup")) {
+    if (accessToken) {
+      return NextResponse.redirect(new URL("/", request.nextUrl.origin));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/mypage/:path*", "/login", "/signup"],
+};

--- a/src/queries/auth/useLogin.ts
+++ b/src/queries/auth/useLogin.ts
@@ -14,8 +14,10 @@ export const useLogin = () => {
     onSuccess: (data) => {
       if (data.success) {
         // 쿠키 설정
-        Cookies.set("accessToken", data.data.accessToken.token);
-        Cookies.set("tokenExpiresAt", String(data.data.accessToken.expiredAt));
+        Cookies.set("accessToken", data.data.accessToken.token, {
+          secure: true,
+          sameSite: "lax",
+        });
 
         // 유저 정보 업데이트
         const user: User = {
@@ -26,6 +28,7 @@ export const useLogin = () => {
           interestCategories: data.data.interestCategories,
         };
         queryClient.setQueryData(["user"], user);
+        queryClient.refetchQueries({ queryKey: ["gatherings"] });
 
         router.push("/");
       }

--- a/src/queries/auth/useLogout.ts
+++ b/src/queries/auth/useLogout.ts
@@ -1,20 +1,16 @@
 import { logoutApi } from "@/api/auth/auth";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 import Cookies from "js-cookie";
 
 export const useLogout = () => {
-  const router = useRouter();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: logoutApi,
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: ["gatherings"] });
-      queryClient.setQueryData(["user"], null);
-      queryClient.removeQueries({ queryKey: ["user"] });
-      router.push("/");
+      queryClient.clear();
       Cookies.remove("accessToken");
+      window.location.href = "/";
     },
   });
 };

--- a/src/queries/auth/useLogout.ts
+++ b/src/queries/auth/useLogout.ts
@@ -1,0 +1,20 @@
+import { logoutApi } from "@/api/auth/auth";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import Cookies from "js-cookie";
+
+export const useLogout = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logoutApi,
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ["gatherings"] });
+      queryClient.setQueryData(["user"], null);
+      queryClient.removeQueries({ queryKey: ["user"] });
+      router.push("/");
+      Cookies.remove("accessToken");
+    },
+  });
+};


### PR DESCRIPTION
## 🔢 관련 이슈
- close #56

## 📌 작업 개요
- 리프레시토큰과 로그아웃 api 연동
- 접근 제어를 위한 미들웨어 추가

## 📝 작업 상세
1. Access Token 갱신 로직 추가
   - 401 에러 발생 시 refresh token으로 access token 자동 갱신
   - 갱신 실패 시 로그아웃 처리

2. 로그아웃 기능 및 인증 관련 코드 정리
   - useLogout 훅 구현
   - 쿠키 보안 설정 강화 (secure, sameSite 옵션 추가)

3. 미들웨어 구현
   - 비로그인 시 /mypage 접근 차단
   - 로그인 시 /login, /signup 접근 차단

## 🎸 기타 참고 사항
### **로컬 HTTPS 개발 환경 설정**  
로컬에서 Set-Cookie 테스트를 위해 HTTPS 설정이 추가되었습니다. 
아래 순서대로 따라 설정해주세요! (MacOS 기준)

1. **`/etc/hosts` 파일 수정**
    ```bash
    sudo vim /etc/hosts

    # 다음 줄 추가
    127.0.0.1 local.momoim.co.kr
    
    # 저장 후 나가기 (ESC + :wq)
    ```

2. **`mkcert` 설치 및 설정**
   ```bash
   # mkcert 설치
   brew install mkcert

   # mkcert 초기화 (로컬 인증기관 설치)
   mkcert -install

   # local.momoim.co.kr 도메인용 인증서 생성
   mkcert local.momoim.co.kr
   ```

3. **DNS 캐시 초기화**
   ```bash
   sudo dscacheutil -flushcache
   sudo killall -HUP mDNSResponder
   ```

- 위 과정을 모두 완료하신 후, `npm run dev:https` 명령어로 실행 (`package.json`에 `npm run dev:https` 추가했습니다)
- https://local.momoim.co.kr:3000 에서 테스트