### PR TITLE
fix: 이미지 콘솔 경고 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,13 @@ const nextConfig = {
   },
 
   images: {
-    domains: ["i.ibb.co", "prod-momoim-bucket.s3.ap-northeast-2.amazonaws.com"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "prod-momoim-bucket.s3.ap-northeast-2.amazonaws.com",
+        pathname: "**",
+      },
+    ],
   },
 
   async redirects() {

--- a/src/app/(main)/gatherings/[id]/_component/DetailCardMember.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/DetailCardMember.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import DefaultProfile from "@/assets/svg/default-profile.svg";
 import { Members } from "@/types/common/members";
 import clsx from "clsx";
-import { Search, Ellipsis, Divide } from "lucide-react";
+import { Search, Ellipsis } from "lucide-react";
 import { Modal } from "@/components/common/modal/Modal";
 import { useState } from "react";
 import { DetailContent } from "@/types/common/gatheringContent";
@@ -41,7 +41,13 @@ export default function DetailCardMember({ data, members, managerName, defaultVi
                       {member.profileImage === "DEFAULT_PROFILE_IMAGE" ? (
                         <DefaultProfile />
                       ) : (
-                        <Image alt="member-image" layout="fill" objectFit="cover" src={member.profileImage} />
+                        <Image
+                          alt="member-image"
+                          fill
+                          sizes="100%"
+                          className="object-cover"
+                          src={member.profileImage}
+                        />
                       )}
                     </div>
                   );

--- a/src/app/(main)/gatherings/[id]/_component/DetailCardMember.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/DetailCardMember.tsx
@@ -29,7 +29,7 @@ export default function DetailCardMember({ data, members, managerName, defaultVi
           title="맴버 리스트"
           size="max-xs:w-11/12"
           triggerButton={
-            <div className="flex cursor-pointer items-center gap-2">
+            <div className="flex cursor-pointer items-center gap-2" role="button">
               <div className="flex gap-2.5">
                 {members?.map((member, idx) => {
                   if (defaultView ? idx >= 6 : idx >= 4) return null;
@@ -54,7 +54,7 @@ export default function DetailCardMember({ data, members, managerName, defaultVi
                 })}
               </div>
               {data?.participantCount > 6 && <Ellipsis className="h-4 w-4" />}
-              <button type="button">
+              <button type="button" aria-label="맴버리스트 더보기">
                 <Search className="h-5 w-5 text-gray-700" />
               </button>
             </div>

--- a/src/app/(main)/gatherings/[id]/_component/MemberModal.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/MemberModal.tsx
@@ -91,7 +91,7 @@ export default function MemberModal({ members, managerName, setMemberOpen }: Mem
                 {profileImage === "DEFAULT_PROFILE_IMAGE" ? (
                   <DefaultProfile />
                 ) : (
-                  <Image src={profileImage} layout="fill" objectFit="cover" alt="member-image" />
+                  <Image src={profileImage} fill sizes="100%" className="object-cover" alt="member-image" />
                 )}
               </div>
               <span className="w-3/4 overflow-hidden text-ellipsis whitespace-nowrap max-xs:w-36">{name}</span>

--- a/src/app/(main)/gatherings/[id]/layout.tsx
+++ b/src/app/(main)/gatherings/[id]/layout.tsx
@@ -35,7 +35,7 @@ export default async function Layout({ children, params }: LayoutProps) {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className="justify-betwee flex gap-14">
+      <div className="justify-betwee flex gap-10">
         <div className="flex flex-1 flex-col gap-6">
           <BackButton home />
           <GatheringDeteilContent id={id} />

--- a/src/app/(main)/gatherings/create/_component/AddressInput.tsx
+++ b/src/app/(main)/gatherings/create/_component/AddressInput.tsx
@@ -40,6 +40,8 @@ export default function AddressInput({ form, field }: FormFieldProps) {
             value={field.value}
             className="h-12 w-full cursor-pointer rounded-md border border-gray-500 px-3 py-1 font-medium text-gray-700"
             placeholder="클릭을 통해 주소를 검색해주세요."
+            aria-label="주소 검색"
+            role="button"
             readOnly
           />
         }

--- a/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
+++ b/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
@@ -27,13 +27,13 @@ export default function GatheringUploadImage({ form, field }: FormFieldProps) {
 
   return (
     <div className="flex items-end gap-4 transition-all max-sm:flex-col max-sm:items-baseline">
-      <div className="flex h-56 w-3/4 items-end rounded-xl border border-gray-500 transition-all max-sm:h-64 max-sm:w-full">
+      <div className="relative flex h-56 w-3/4 items-end rounded-xl border border-gray-500 transition-all max-sm:aspect-video max-sm:h-auto max-sm:w-full">
         <Image
           src={imageValue || DefaultThumbnail}
-          className="h-full w-full rounded-xl object-cover"
-          width={500}
-          height={500}
+          className="rounded-xl object-cover"
           alt="모임 생성 이미지"
+          fill
+          sizes="100%"
           priority
         />
       </div>

--- a/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
+++ b/src/app/(main)/gatherings/create/_component/GatheringUploadImage.tsx
@@ -34,7 +34,7 @@ export default function GatheringUploadImage({ form, field }: FormFieldProps) {
           width={500}
           height={500}
           alt="모임 생성 이미지"
-          priority={!imageValue}
+          priority
         />
       </div>
       <div className="flex w-full gap-2">

--- a/src/app/(main)/mypage/_components/ProfileBox.tsx
+++ b/src/app/(main)/mypage/_components/ProfileBox.tsx
@@ -82,7 +82,9 @@ export default function ProfileBox() {
                     : thumbnail.src
                 }
                 fill
+                sizes="100%"
                 className="object-cover"
+                priority
               />
             </div>
             <div className="flex flex-col justify-center p-6">

--- a/src/app/(main)/mypage/_components/ProfileEdit.tsx
+++ b/src/app/(main)/mypage/_components/ProfileEdit.tsx
@@ -101,6 +101,7 @@ export default function ProfileEdit({ data, openSwitch }: Props) {
                   <Image
                     alt="thumbnail"
                     fill
+                    sizes="100%"
                     className="rounded-[20px] border-2 border-solid border-gray-200 object-cover"
                     src={currentProfileImage || thumbnail.src}
                   />

--- a/src/app/(main)/mypage/_components/ScheduleCard.tsx
+++ b/src/app/(main)/mypage/_components/ScheduleCard.tsx
@@ -27,6 +27,7 @@ export default function ScheduleCard({ data }: Props) {
             alt="thumbnail"
             src={data?.gatheringImage ? data?.gatheringImage : thumbnail.src}
             fill
+            sizes="100%"
             className="object-cover"
           />
         </div>

--- a/src/app/(main)/mypage/_components/UnreviewedCard.tsx
+++ b/src/app/(main)/mypage/_components/UnreviewedCard.tsx
@@ -22,7 +22,14 @@ export default function UnreviewedCard({ data }: Props) {
     <div className="max-w-[375px]">
       <div className="flex w-full items-center gap-2 py-2 sm:items-center">
         <div className="relative flex aspect-square h-[20%] w-[20%] items-center justify-center overflow-hidden rounded-xl border-2 border-solid border-gray-200 xs:h-24 xs:w-24">
-          <Image alt="thumbnail" src={data?.image ? data?.image : thumbnail.src} fill className="object-cover" />
+          <Image
+            alt="thumbnail"
+            src={data?.image ? data?.image : thumbnail.src}
+            fill
+            sizes="100%"
+            className="object-cover"
+            priority
+          />
         </div>
         <div
           className={`flex h-24 min-w-0 flex-grow flex-col justify-center gap-1 pl-2 ${(data?.status === "CANCELED" || data?.status === "FINISHED") && "opacity-30"}`}

--- a/src/app/_component/BackButton.tsx
+++ b/src/app/_component/BackButton.tsx
@@ -11,7 +11,7 @@ export default function BackButton({ home = false }: { home?: boolean }) {
 
   return (
     <div>
-      <button type="button" className="p-1 pl-0" onClick={handleBack}>
+      <button type="button" className="p-1 pl-0" onClick={handleBack} aria-label={home ? "홈으로 가기" : "뒤로 가기"}>
         <ArrowLeft className="h-6 w-6" />
       </button>
     </div>

--- a/src/components/common/cards/DetailCard.tsx
+++ b/src/components/common/cards/DetailCard.tsx
@@ -22,7 +22,7 @@ export default function DetailCard({ id, detailData }: { id: number; detailData:
           width={500}
           height={500}
           alt="모임 상세 이미지"
-          priority={!data.image}
+          priority
         />
       </div>
       <div className="flex flex-1 flex-col justify-between gap-3">
@@ -74,8 +74,9 @@ export default function DetailCard({ id, detailData }: { id: number; detailData:
                   <DefaultProfile />
                 ) : (
                   <Image
-                    layout="fill"
-                    objectFit="cover"
+                    fill
+                    sizes="100%"
+                    className="object-cover"
                     alt="managerProfileImage"
                     src={data.managerProfileImage || ""}
                   />

--- a/src/components/common/cards/DetailCard.tsx
+++ b/src/components/common/cards/DetailCard.tsx
@@ -15,13 +15,13 @@ export default function DetailCard({ id, detailData }: { id: number; detailData:
 
   return (
     <div className="flex h-full w-full flex-wrap items-center gap-4 max-md:justify-center">
-      <div className="flex h-56 w-60 items-center justify-center overflow-hidden rounded-[20px] border-2 border-solid border-gray-200 max-md:w-full">
+      <div className="relative flex h-56 w-60 items-center justify-center overflow-hidden rounded-[20px] border-2 border-solid border-gray-200 max-md:aspect-video max-md:h-auto max-md:w-full">
         <Image
           src={data.image || DefaultThumbnail}
-          className="h-full w-full rounded-xl object-cover"
-          width={500}
-          height={500}
+          className="rounded-xl object-cover"
           alt="모임 상세 이미지"
+          fill
+          sizes="100%"
           priority
         />
       </div>

--- a/src/components/common/cards/MoimCard.tsx
+++ b/src/components/common/cards/MoimCard.tsx
@@ -111,7 +111,14 @@ export default function MoimCard({ type, data, customOnClick }: Props) {
               }[data?.status as string] || ""}
             </div>
           ) : (
-            <Image alt="thumbnail" src={data?.image ? data?.image : thumbnail.src} fill className="object-cover" />
+            <Image
+              alt="thumbnail"
+              src={data?.image ? data?.image : thumbnail.src}
+              fill
+              sizes="100%"
+              className="object-cover"
+              priority
+            />
           )}
         </div>
         <div

--- a/src/components/common/editor/Tiptab.tsx
+++ b/src/components/common/editor/Tiptab.tsx
@@ -75,6 +75,7 @@ function TipTab({ field }: FormDescriptionProps) {
             if (e.key === "Enter" || e.key === " ") handleEditorClick();
           }}
           role="textbox"
+          aria-label="텍스트 에디터"
           tabIndex={0}
         >
           <Toolbar editor={editor} />

--- a/src/components/common/editor/TiptabImage.tsx
+++ b/src/components/common/editor/TiptabImage.tsx
@@ -11,7 +11,7 @@ export default function TiptabImage({ editor }: { editor: Editor | null }) {
 
     if (selectFile && editor) {
       const uploadImage = await ImageUploadApi("editorImage", selectFile);
-      editor.chain().focus().setImage({ src: uploadImage }).run();
+      editor.chain().focus().setImage({ src: uploadImage, alt: "에디터 첨부 이미지" }).run();
 
       const { to } = editor.state.selection;
       const tr = editor.state.tr.insert(to, editor.schema.nodes.paragraph.create());

--- a/src/components/common/editor/TiptabLink.tsx
+++ b/src/components/common/editor/TiptabLink.tsx
@@ -43,7 +43,7 @@ export default function TiptabLink({ editor }: { editor: Editor | null }) {
         open={open}
         action={setOpen}
         size="max-xs:w-80 gap-0"
-        triggerButton={<LinkIcon className="h-5 w-5 cursor-pointer" />}
+        triggerButton={<LinkIcon className="h-5 w-5 cursor-pointer" role="button" aria-label="링크 첨부" />}
         content={
           <div className="flex w-full items-center justify-center gap-4">
             <input

--- a/src/components/common/editor/Toolbar.tsx
+++ b/src/components/common/editor/Toolbar.tsx
@@ -13,6 +13,7 @@ export default function Toolbar({ editor }: { editor: Editor | null }) {
           type="button"
           className="toolbarBtn"
           onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+          aria-label="제목 크기 1"
         >
           <Heading1 className="h-5 w-5" />
         </button>
@@ -20,6 +21,7 @@ export default function Toolbar({ editor }: { editor: Editor | null }) {
           type="button"
           className="toolbarBtn"
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          aria-label="제목 크기 2"
         >
           <Heading2 className="h-5 w-5 cursor-pointer" />
         </button>
@@ -27,28 +29,54 @@ export default function Toolbar({ editor }: { editor: Editor | null }) {
           type="button"
           className="toolbarBtn"
           onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+          aria-label="제목 크기 3"
         >
           <Heading3 className="h-5 w-5 cursor-pointer" />
         </button>
         <div className="h-5 w-[1px] bg-gray-400" />
       </div>
       <div className="flex items-center gap-4 transition-all max-sm:gap-1">
-        <button type="button" className="toolbarBtn" onClick={() => editor.chain().focus().toggleBold().run()}>
+        <button
+          type="button"
+          className="toolbarBtn"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          aria-label="텍스트 진하게"
+        >
           <Bold className="h-5 w-5 cursor-pointer" />
         </button>
-        <button type="button" className="toolbarBtn" onClick={() => editor.chain().focus().toggleItalic().run()}>
+        <button
+          type="button"
+          className="toolbarBtn"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          aria-label="텍스트 기울기"
+        >
           <Italic className="h-5 w-5 cursor-pointer" />
         </button>
-        <button type="button" className="toolbarBtn" onClick={() => editor.chain().focus().toggleUnderline().run()}>
+        <button
+          type="button"
+          className="toolbarBtn"
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          aria-label="텍스트 밑줄"
+        >
           <Underline className="h-5 w-5 cursor-pointer" />
         </button>
         <div className="h-5 w-[1px] bg-gray-400" />
       </div>
       <div className="flex items-center gap-4 transition-all max-sm:gap-1">
-        <button type="button" className="toolbarBtn" onClick={() => editor.chain().focus().toggleBulletList().run()}>
+        <button
+          type="button"
+          className="toolbarBtn"
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          aria-label="순서가 없는 리스트 정렬"
+        >
           <List className="h-5 w-5 cursor-pointer" />
         </button>
-        <button type="button" className="toolbarBtn" onClick={() => editor.chain().focus().toggleOrderedList().run()}>
+        <button
+          type="button"
+          className="toolbarBtn"
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          aria-label="순서가 있는 리스트 정렬"
+        >
           <ListOrdered className="h-5 w-5 cursor-pointer" />
         </button>
         <div className="h-5 w-[1px] bg-gray-400" />


### PR DESCRIPTION
## 🔢 관련 이슈

> 이슈번호를 입력해주세요. ex) #001

- close #

## 📌 작업 개요

> 간략하게 작업한 내용을 작성해주세요.

- local에서 이미지 사용하는 페이지 콘솔 경고 수정

<img width="458" alt="스크린샷 2025-01-22 오후 2 44 08" src="https://github.com/user-attachments/assets/f2f46155-7686-431a-8449-d13fa7538f87" />
<img width="472" alt="스크린샷 2025-01-22 오후 2 41 23" src="https://github.com/user-attachments/assets/9b26a704-b2c9-4bdf-9ba4-74f27c9e1269" />


## 📝 작업 상세

> 작업한 내용을 상세하게 작성해주세요. (작성 후 하단 이미지 첨부가능)

- 이미지 경고 페이지 (상세, 마이페이지)
- 위 경고들을 해결하기위해 변경된 옵션 제거 및 수정
- nextconfig images.domains 경고를 보면 더 이상 사용하지 않으므로 images.remotePatterns으로 변경
- 상세페이지 썸네일 반응형 비율 수정 및 button role 추가
- 에디터 이미지 첨부 시 alt 및 aria-label, role 누락 추가

## 🎸 기타 참고 사항

> (선택) 참고할 자료나 코드리뷰 할때 특정 코드부분 자세히 봐주면 좋겠다는 사항을 작성해주세요.

태희님 마이페이지 쪽도 수정해서 참고 부탁드립니다.
